### PR TITLE
Adjust unit scale to two inches

### DIFF
--- a/ProjectSettings/DynamicsManager.asset
+++ b/ProjectSettings/DynamicsManager.asset
@@ -4,7 +4,7 @@
 PhysicsManager:
   m_ObjectHideFlags: 0
   serializedVersion: 13
-  m_Gravity: {x: 0, y: -9.81, z: 0}
+  m_Gravity: {x: 0, y: -193.30709, z: 0}
   m_DefaultMaterial: {fileID: 0}
   m_BounceThreshold: 2
   m_DefaultSolverIterations: 6

--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 This repository now contains a Unity 2022.3 LTS 3D project scaffold for building a pinball simulator. The project includes a starter scene with a camera, directional light, and a simple ground plane so the editor immediately displays 3D content. Open the project in Unity 2022.3.10f1 (or a compatible 2022.3 LTS version) to begin development.
 
+## Unit scale
+
+The project is configured so that **1 Unity unit represents 2 inches** instead of the default 1 meter. Physics gravity has been adjusted accordingly to keep motion consistent with real-world behaviour at this scale.
+
 ## Project Structure
 
 - `Assets/` – Application content, currently containing a SampleScene under `Assets/Scenes`.


### PR DESCRIPTION
## Summary
- set the 3D physics gravity to match a 2 inch per unit scale
- document the custom unit scale in the project README

## Testing
- not run (project settings only)


------
https://chatgpt.com/codex/tasks/task_e_68cd3233a9dc832285f5239d0120082d